### PR TITLE
Change api rate limit arguments to refer to the doc read rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ const opts = {
 	// This will indirectly set the number of docs to batch read per request.
 	// Recommended to set this around 256KB - 1MB (the higher the better, usually).
 	// Setting this too high may overwhelm couchdb.
-	// defaults 1048576 (1MB)
-	batch_get_bytes_goal: 1 * 1024 * 1024,
+	// defaults 131072 (128KB)
+	batch_get_bytes_goal: 128 * 1024,
 
-	// [optional] the maximum number of apis to spawn per second.
+	// [optional] the maximum number of read queries to spawn per second.
 	// If this the rate limit is unknown, leave blank.
 	// This lib will auto detect the real rate limit.
 	// It will back off once a 429 response code is found.
@@ -67,19 +67,20 @@ const opts = {
 
 	// [optional] the maximum number of read queries to be waiting on.
 	// Setting this too high may overwhelm couchdb (10-50 seems okay).
-	// defaults 25
-	max_parallel_reads: 30,
+	// defaults to Math.floor(max_rate_per_sec / get_doc_batch_size) * 2
+	// recommended to leave it blank
+	max_parallel_reads: undefined,
 
 	// [optional] how much of the real rate limit should be left for other applications.
 	// example if 20 is set then only 80% of the detected-rate limit will be used.
 	// defaults 20
 	head_room_percent: 18,
 
-	// [optional] the minimum number of apis to spawn per second.
+	// [optional] the minimum number of read queries per second.
 	// when the lib encounters a 429 response code it lowers its internal limit.
 	// this setting will create a floor for the internal limit.
-	// defaults 2
-	min_rate_per_sec: 2,
+	// defaults 50
+	min_rate_per_sec: 50,
 
 	// [optional] the maximum amount of time to wait on an read api in milliseconds.
 	// defaults 240000 (4 minutes)

--- a/libs/misc.js
+++ b/libs/misc.js
@@ -118,8 +118,8 @@ module.exports = function () {
 		if (isNaN(opts.max_rate_per_sec)) {
 			errors.push('"max_rate_per_sec" must be a number');
 		}
-		if (isNaN(opts.max_parallel_reads)) {
-			errors.push('"max_parallel_reads" must be a number');
+		if (isNaN(opts.max_parallel_reads) && opts.max_parallel_reads) {
+			errors.push('"max_parallel_reads" must be a number or falsey');
 		}
 		if (isNaN(opts.head_room_percent)) {
 			errors.push('"head_room_percent" must be a number');

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"eslint": "^7.20.0"
 			},
 			"engines": {
-				"node": "^8.16.0"
+				"node": "^16.14.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -1073,9 +1073,9 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
@@ -1197,9 +1197,9 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+			"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
 			"engines": {
 				"node": ">=0.6"
 			}
@@ -2463,9 +2463,9 @@
 			}
 		},
 		"minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
@@ -2560,9 +2560,9 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
 		"qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+			"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
 		},
 		"regexpp": {
 			"version": "3.1.0",

--- a/test/manual.js
+++ b/test/manual.js
@@ -7,11 +7,13 @@ const opts = {
 	couchdb_url: secrets.couchdb_url,
 	db_name: secrets.db_name,
 	iam_apikey: secrets.apikey,
-	max_rate_per_sec: 50,
-	max_parallel_reads: 50,
-	head_room_percent: 20,
-	batch_get_bytes_goal: 1 * 1024 * 1024,
+	max_rate_per_sec: 800,
+	min_rate_per_sec: 100,
+	//max_parallel_reads: 50,
+	head_room_percent: 15,
+	batch_get_bytes_goal: 32 * 1024,
 	write_stream: fs.createWriteStream('./_backup_docs.json'),
+	_MAX_STUBS_IN_MEMORY: 1e6,
 };
 rapid_couchdb.backup(opts, (errors, date_completed) => {
 	console.log('the end:', date_completed);


### PR DESCRIPTION
Changed the rate limit calculation from APIs per second to doc reads per second to match a Cloudant change.  Therefore if 1 `bulk GET` API is being sent at a rate of 1 per second and its fetching 100 docs each time, that would be a rate of 100 docs per second. The parameters `max_rate_per_sec` now refer to docs per second (prior to this PR they refereed to APIs per second).

More Background:
Due to a calculation change on Cloudant's part this PR is needed to stay under the service's query limits. Bulk APIs previously counted as 1 read, now they count as the number of docs they included... Potentially thousands per second!

